### PR TITLE
Typo in CL-433 Colony Incident Report.txt

### DIFF
--- a/Main/Updated RMC14/Weston-Yamada/CL-433 Colony Incident Report.txt
+++ b/Main/Updated RMC14/Weston-Yamada/CL-433 Colony Incident Report.txt
@@ -9,7 +9,7 @@ has been authorized by the UNMC or the Weston-Yamada Corporation.[/bolditalic]
 
 [italic]The Shipside Liaison is expected to acknowledge the reason for investigation, identify the events resulting in the investigation, explain what action is being taken by UNMC and Weston-Yamada personnel, form conclusions, and highlight any further recommendations to prevent or minimize future incidents that may occur.[/italic] 
 [italic][bold][color=#383838]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color][/bold][/italic]
-[bullet/][bold]Operation Name:[/bold ]WRITEHERE
+[bullet/][bold]Operation Name:[/bold]WRITEHERE
 [bullet/][bold]Responding UNMC Assets:[/bold] WRITEHERE
 [bullet/][bold]Reason for Investigation:[/bold] WRITEHERE
 [bullet/][bold]Cause of Incident:[/bold] WRITEHERE


### PR DESCRIPTION
Fixed a typo:
[/bold ] > [/bold]