### PR TITLE
Intel Personnel Roster, Intel Fireteam Roster, and Chain of Custody documents

### DIFF
--- a/Main/WIP Submissions/Aux (Intel+Flight staff)/X-I501 Intel Personnel Roster.txt
+++ b/Main/WIP Submissions/Aux (Intel+Flight staff)/X-I501 Intel Personnel Roster.txt
@@ -1,0 +1,35 @@
+[color=#287015]█[/color][color=#ffffff]░░[/color][color=#383838]█[/color] [color=#287015]█▄[/color] [color=#383838]█[/color] [head=3]U[/head][bold]nited [head=3]N[/head]ations [head=3]M[/head]arine [head=3]C[/head]orps[/bold]     [bold]Form:  [/bold][color=#ff0000]X-I501[/color]
+[color=#383838]▀▄▄[/color][color=#287015]▀[/color] [color=#383838]█[/color] [color=#287015]▀█[/color] [color=#AAAAAA][italic]UNS Almayer; 2nd Company "Falling Falcons"[/color][/italic]
+[color=#383838]▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀[/color]
+          [head=1][color=#72856d]Intel[/color] Personnel Roster[/head]
+                                        
+[bold][color=#287015]Intelligence Officer(s):[/bold][/color]
+    [bold]Name:[/bold] [color=#72856d][italic]RANK NAME[/italic][/color]
+    [bold]Responsibility:[/bold] [color=#72856d][italic](Intel Gathering OR Intelligence Overwatch)[/italic][/color]
+    [bold]Fireteam [color=#AAAAAA][italic](if applicable)[/italic][/color]:[/bold] [color=#72856d][italic](N/A, FT1/2/3, FTL1/2/3)[/italic][/color]
+        [bold]Members of Fireteam:[/bold]
+            [bullet/] [color=#72856d][italic]RANK NAME, ROLE[/italic][/color]
+                                      ---
+    [bold]Name:[/bold] [color=#72856d][italic]RANK NAME[/italic][/color]
+    [bold]Responsibility:[/bold] [color=#72856d][italic](Intel Gathering OR Intelligence Overwatch)[/italic][/color]
+    [bold]Fireteam [color=#AAAAAA][italic](if applicable)[/italic][/color]:[/bold] [color=#72856d][italic](N/A, FT1/2/3, FTL1/2/3)[/italic][/color]
+        [bold]Members of Fireteam:[/bold]
+            [bullet/] [color=#72856d][italic]RANK NAME, ROLE[/italic][/color]
+                                      ---
+    [bold]Name:[/bold] [color=#72856d][italic]RANK NAME[/italic][/color]
+    [bold]Responsibility:[/bold] [color=#72856d][italic](Intel Gathering OR Intelligence Overwatch)[/italic][/color]
+    [bold]Fireteam [color=#AAAAAA][italic](if applicable)[/italic][/color]:[/bold] [color=#72856d][italic](N/A, FT1/2/3, FTL1/2/3)[/italic][/color]
+        [bold]Members of Fireteam:[/bold]
+            [bullet/] [color=#72856d][italic]RANK NAME, ROLE[/italic][/color]
+                                      ---
+
+[bold]Total:[/bold] [italic]#[/italic]
+
+[bold]Aditional Notes:[/bold]
+ [italic]Write Here[/italic]
+[italic][bold][color=#134975]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color][/bold][/italic]
+[bold]Certified by,[/bold]
+[italic]RANK NAME[/italic]
+[bold]ROLE[/bold]
+[color=#AAAAAA]===================================================[/color]
+[italic][color=#E41B1B]Use of this document inconsistent with UCMJ regulations and UNMC policy MIL-891 is a violation of federal law and will result in prosecution.[/color][/italic]

--- a/Main/WIP Submissions/Aux (Intel+Flight staff)/X-I502 Intel Fireteam Roster.txt
+++ b/Main/WIP Submissions/Aux (Intel+Flight staff)/X-I502 Intel Fireteam Roster.txt
@@ -1,0 +1,23 @@
+[color=#287015]█[/color][color=#ffffff]░░[/color][color=#383838]█[/color] [color=#287015]█▄[/color] [color=#383838]█[/color] [head=3]U[/head][bold]nited [head=3]N[/head]ations [head=3]M[/head]arine [head=3]C[/head]orps[/bold]     [bold]Form:  [/bold][color=#ff0000]X-I502[/color]
+[color=#383838]▀▄▄[/color][color=#287015]▀[/color] [color=#383838]█[/color] [color=#287015]▀█[/color] [color=#AAAAAA][italic]UNS Almayer; 2nd Company "Falling Falcons"[/color][/italic]
+[color=#383838]▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀[/color]
+          [head=1][color=#72856d]Intel[/color] Fireteam Roster[/head]
+
+[bold][color=#287015]Intel Fireteam(s):[/bold][/color]
+    [bold]Team 1:[/bold]
+        [bullet/] [color=#72856d][italic]RANK NAME, ROLE[/italic][/color]
+                                      ---
+    [bold]Team 2:[/bold]
+        [bullet/] [color=#72856d][italic]RANK NAME, ROLE[/italic][/color]
+                                      ---
+    [bold]Team 3:[/bold]
+        [bullet/] [color=#72856d][italic]RANK NAME, ROLE[/italic][/color]
+                                      ---
+[bold]Total:[/bold] [italic]#[/italic]
+
+[italic][bold][color=#134975]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color][/bold][/italic]
+[bold]Certified by,[/bold]
+[italic]RANK NAME[/italic]
+[bold]ROLE[/bold]
+[color=#AAAAAA]===================================================[/color]
+[italic][color=#E41B1B]Use of this document inconsistent with UCMJ regulations and UNMC policy MIL-891 is a violation of federal law and will result in prosecution.[/color][/italic]

--- a/Main/WIP Submissions/Aux (Intel+Flight staff)/X-I64 Chain of Custody.txt
+++ b/Main/WIP Submissions/Aux (Intel+Flight staff)/X-I64 Chain of Custody.txt
@@ -1,0 +1,34 @@
+[color=#287015]█[/color][color=#ffffff]░░[/color][color=#383838]█[/color] [color=#287015]█▄[/color] [color=#383838]█[/color] [head=3]U[/head][bold]nited [head=3]N[/head]ations [head=3]M[/head]arine [head=3]C[/head]orps[/bold]     [bold]Form:  [/bold][color=#ff0000]X-I640[/color]
+[color=#383838]▀▄▄[/color][color=#287015]▀[/color] [color=#383838]█[/color] [color=#287015]▀█[/color] [color=#AAAAAA][italic]UNS Almayer; 2nd Company "Falling Falcons"[/color][/italic]
+[color=#383838]▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀[/color]
+                   [head=1]CHAIN OF CUSTODY[/head]
+
+[bold]Type of document/device:[/bold] [italic]Write Here[/italic]
+[bold]Item Designation:[/bold] [color=#ff0000][italic]###[/italic][/color]
+[bold]Item Serial Number [color=#AAAAAA][italic](if applicable)[/italic][/color]:[/bold] [color=#ff0000][italic]########[/italic][/color]
+[bold]Received from:[/bold] [color=#75946d][italic]RANK NAME[/italic][/color]
+[bold]Received by:[/bold] [color=#72856d][italic]RANK NAME[/italic][/color]
+[bold]Date:[/bold] [italic]______________[/italic][bold]Time:[/bold][italic]______________[/italic]
+
+[italic][bold][color=#134975]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color][/bold][/italic]
+
+[bold]Date of collection:[/bold] [italic]___________[/italic]
+[bold]Time of collection:[/bold] [italic]___________[/italic]
+[bold]Collected by:[/bold] [color=#75946d][italic]RANK NAME[/italic][/color]
+[bold]Description of item:[/bold]
+    [bullet/] [italic]Describe Here[/italic]
+
+[bold]Location where collected:[/bold]
+    [bullet/] [italic]Location Here[/italic]
+
+[bold]Additional Comments:[/bold]
+    [bullet/] [italic]Write Here[/italic]
+
+[italic][bold][color=#134975]‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾‾[/color][/bold][/italic]
+[bold]Certified by,[/bold]
+[italic]RANK NAME[/italic]
+[bold]ROLE[/bold]
+[color=#AAAAAA]===================================================
+[bullet/][italic]Failure to accurately complete this document may compromise the integrity of collected intelligence, rendering it unreliable for operational use.[/italic]
+[bullet/][italic]Noncompliance with UNMC Intelligence Gathering Policy X-I406 constitutes a violation of military regulations and may result in disciplinary action or prosecution under applicable law.[/italic][/color]
+[italic][color=#E41B1B]Use of this document inconsistent with UCMJ regulations and UNMC policy MIL-891 is a violation of federal law and will result in prosecution.[/color][/italic]


### PR DESCRIPTION
Because who _doesn't_ love more paperwork to fill out!

This adds three new documents to the WIP Aux section:

- Intel Personnel Roster document, which is more focused on the individual IOs and the fireteam _(if any)_ attached to them.
- Intel Fireteam Roster document, which is more focused on the fireteams themselves.
- Chain of Custody document, which is used to torture the ASO with paperwork they must fill out for each and every piece of intel that arrives at the lab. 



